### PR TITLE
create a new line after semicolon and move the cursor down after semi…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,22 @@ function complete_statement(textEditor: vscode.TextEditor,
 {
     let current_line_number: number = textEditor.selection.start.line
     let current_line: vscode.TextLine = textEditor.document.lineAt(current_line_number)
+    
+    // Get indentation level here for use with either
+    // new lines after semicolon or new block of code.
+    // Assuming use spaces to indent.
+    const tab_stop: number = vscode.workspace.getConfiguration('editor').get('tabSize', 4)
+    let indent_level: number = 0
+    if (current_line.text.startsWith(' ')) // indented
+    {
+        const indent_position: number =
+                current_line.text.lastIndexOf(" ".repeat(tab_stop))
+        indent_level = indent_position / tab_stop + 1
+    }
+    const indent_space_count: number = tab_stop * (indent_level + 1)
+    const indent_spaces: string = " ".repeat(indent_space_count)
+    const less_indent_spaces: string = " ".repeat(tab_stop * indent_level)
+    
     if (current_line.text.trim() === '}')
     {
         vscode.commands.executeCommand('cursorMove', {'to': 'up'})
@@ -37,22 +53,17 @@ function complete_statement(textEditor: vscode.TextEditor,
         }
         else
         {
-            // Assuming use spaces to indent.
-            const tab_stop: number = vscode.workspace.getConfiguration('editor').get('tabSize', 4)
-            let indent_level: number
-            if (current_line.text.startsWith(' ')) // indented
-            {
-                const indent_position: number =
-                        current_line.text.lastIndexOf(" ".repeat(tab_stop))
-                indent_level = indent_position / tab_stop + 1
+            // After completion, vscode will move the cursor to the end of the added text
+            // if the cursor is currently at the end of the line, otherwise the cursor
+            // stays on the current line.  Figure out is_at_end here.
+            const editor = vscode.window.activeTextEditor
+            let position : vscode.Position
+            let is_at_end : boolean = false
+            if (editor) {
+                position = editor.selection.active
+                is_at_end = position.character == current_line.range.end.character
             }
-            else
-            {
-                indent_level = 0
-            }
-            const indent_space_count: number = tab_stop * (indent_level + 1)
-            const indent_spaces: string = " ".repeat(indent_space_count)
-            const less_indent_spaces: string = " ".repeat(tab_stop * indent_level)
+
             let braces: string
             const allman: boolean =
                     vscode.workspace.getConfiguration('complete-statement').get('allman', false)
@@ -61,7 +72,6 @@ function complete_statement(textEditor: vscode.TextEditor,
                 braces = `\n${less_indent_spaces}{\n${indent_spaces}` +
                         `\n${less_indent_spaces}}`
                 textEditorEdit.insert(current_line.range.end, braces)
-                vscode.commands.executeCommand('cursorMove', {'to': 'wrappedLineEnd'})
             }
             else
             {
@@ -75,8 +85,8 @@ function complete_statement(textEditor: vscode.TextEditor,
                     braces = ` ${braces}`
                 }
                 textEditorEdit.insert(current_line.range.end, braces)
-                vscode.commands.executeCommand('cursorMove', {'to': 'left'})
             }
+            
             // Unlike IntelliJ, it does not go to the start (`^` in vim) of new line.
             // You have to press `down` arrow key.
             // Why?
@@ -90,11 +100,24 @@ function complete_statement(textEditor: vscode.TextEditor,
             // The position within the inserted string will be unreachable.
             //
             // See [#11841](https://github.com/Microsoft/vscode/issues/11841)
+
+            // Move the cursor into the newly created block.
+            if (is_at_end) {
+                vscode.commands.executeCommand('cursorMove', {'to': 'up'})
+            }
+            else {
+                vscode.commands.executeCommand('cursorMove', {'to': 'down'})
+            }
+            vscode.commands.executeCommand('cursorMove', {'to': 'wrappedLineEnd'})
         }
     }
     else
     {
-        insert_semicolon_at_line_end(current_line, textEditorEdit)
+        if (current_line.text.trim() !== '' && !current_line.text.endsWith(';')) {
+            textEditorEdit.insert(current_line.range.end, ';')
+        }
+        textEditorEdit.insert(current_line.range.end, '\n' + less_indent_spaces)
+        vscode.commands.executeCommand('cursorMove', {'to': 'down'})
         vscode.commands.executeCommand('cursorMove', {'to': 'wrappedLineEnd'})
     }
 }
@@ -146,32 +169,5 @@ function looks_like_complex_structure(line: vscode.TextLine): boolean
     else
     {
         return false
-    }
-}
-
-function insert_semicolon_at_line_end(line: vscode.TextLine,
-                                      textEditorEdit: vscode.TextEditorEdit
-                                     ): void
-{
-    insert_at_end(';', line, textEditorEdit)
-}
-
-function insert_at_end(character: string,
-                       line: vscode.TextLine, textEditorEdit: vscode.TextEditorEdit
-                      ): void
-{
-    if (line.text.endsWith(character)) {
-        textEditorEdit.insert(line.range.end, '\n')
-    }
-    else
-    {
-        if (character === ',') // always insert blank line for javascript object
-        {
-            textEditorEdit.insert(line.range.end, ',\n')
-        }
-        else
-        {
-            textEditorEdit.insert(line.range.end, character)
-        }
     }
 }


### PR DESCRIPTION
Hi

This tries to handle issue #2 so that the cursor moves to the start of the next line after.  It provides a workaround for the inconsistent behavior of vscode after text insertion by moving in different directions depending on where the cursor is. (This works with v1.33.1)

This changes the behavior of the extension.  A new line is automatically added after a semicolon and the cursor is moved down.  Your users might not be used to this, so you may not want to accept this PR and instead add this behavior as an option.
